### PR TITLE
Add draggable window component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Window } from "@/components/ui/window";
 
 export default function Home() {
   return (
-    <div className="container mx-auto px-4 py-16 max-w-4xl">
+    <div className="container relative mx-auto px-4 py-16 max-w-4xl">
       {/* Hero Section */}
       <header className="mb-16">
         <h1 className="text-4xl font-bold mb-6">
@@ -15,6 +16,10 @@ export default function Home() {
           Designer by practice, engineer by training, researcher at heart. I tackle complex product challenges by combining technical depth with user-centered design, turning ambiguity into actionable insights and shipped solutions.
         </p>
       </header>
+
+      <Window title="Demo">
+        <p>Draggable content goes here.</p>
+      </Window>
 
       <section className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-3 gap-4 mb-16">
         <Card>

--- a/src/components/ui/window.tsx
+++ b/src/components/ui/window.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+let zIndexCounter = 10
+
+interface WindowProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "title"> {
+  title: React.ReactNode
+}
+
+const Window = React.forwardRef<HTMLDivElement, WindowProps>(
+  ({ title, className, children, style, ...props }, ref) => {
+    const [position, setPosition] = React.useState({ x: 100, y: 100 })
+    const [zIndex, setZIndex] = React.useState(() => ++zIndexCounter)
+    const startRef = React.useRef({ x: 0, y: 0 })
+    const originRef = React.useRef({ x: 0, y: 0 })
+    const idRef = React.useRef<number | null>(null)
+
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      idRef.current = e.pointerId
+      ;(e.target as HTMLElement).setPointerCapture(e.pointerId)
+      startRef.current = { x: e.clientX, y: e.clientY }
+      originRef.current = { ...position }
+      setZIndex(++zIndexCounter)
+    }
+
+    const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (idRef.current !== e.pointerId) return
+      e.preventDefault()
+      const dx = e.clientX - startRef.current.x
+      const dy = e.clientY - startRef.current.y
+      setPosition({ x: originRef.current.x + dx, y: originRef.current.y + dy })
+    }
+
+    const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+      if (idRef.current === e.pointerId) {
+        e.preventDefault()
+        ;(e.target as HTMLElement).releasePointerCapture(e.pointerId)
+        idRef.current = null
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        style={{ left: position.x, top: position.y, zIndex, ...style }}
+        className={cn(
+          "absolute w-80 rounded-sm border bg-card text-card-foreground shadow-md",
+          className
+        )}
+        {...props}
+      >
+        <div
+          className="flex select-none items-center justify-between gap-2 bg-muted px-2 py-1 text-sm cursor-move touch-none"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+        >
+          <span className="font-semibold">{title}</span>
+          <div className="flex gap-1">
+            <span className="h-2 w-2 rounded-full bg-destructive" />
+            <span className="h-2 w-2 rounded-full bg-secondary" />
+            <span className="h-2 w-2 rounded-full bg-primary" />
+          </div>
+        </div>
+        <div className="p-2">{children}</div>
+      </div>
+    )
+  }
+)
+Window.displayName = "Window"
+
+export { Window }
+


### PR DESCRIPTION
## Summary
- add a `Window` component for movable window UI
- embed a sample window on the home page
- tweak dragging and styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877ba975d78832abd57de051a11984f