### PR TITLE
Improve close button accessibility

### DIFF
--- a/src/components/ui/window.tsx
+++ b/src/components/ui/window.tsx
@@ -116,13 +116,23 @@ const Window = React.forwardRef<WindowRef, WindowProps>(
           <span className="font-semibold">{title}</span>
           <div className="flex gap-1">
             <button
+              type="button"
               className="size-5 -m-1 p-1 group"
-              onClick={onClose}
+              onClick={(e) => {
+                e.stopPropagation()
+                onClose?.()
+              }}
               aria-label="Close"
             >
-              <X className={cn(
-                "size-3 rounded-full text-muted group-hover:bg-destructive transition-colors",
-                focused ? "bg-primary-foreground text-primary" : "bg-foreground text-muted")} />
+              <X
+                className={cn(
+                  "size-3 rounded-full text-muted group-hover:bg-destructive transition-colors",
+                  focused
+                    ? "bg-primary-foreground text-primary"
+                    : "bg-foreground text-muted"
+                )}
+              />
+              <span className="sr-only">Close</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- make the close button stop event propagation
- add screen-reader only text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d72ab5944832aa3de89d0e734e271