### PR TITLE
Update Experience role copy to match Head of Design CV

### DIFF
--- a/src/components/windows/CandisWindow.tsx
+++ b/src/components/windows/CandisWindow.tsx
@@ -16,8 +16,7 @@ export default function CandisWindow({ onClose, windowRef }: CandisWindowProps) 
       <WindowContent>
         <p className="text-sm text-muted-foreground">2017–2019</p>
         <p className="font-serif text-xl mb-2">I was a design team of one, hands-on from research to frontend at <a href="https://www.candis.io/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "candis_site", url: "https://www.candis.io/" })}>Candis</a>.</p>
-        <p className="mb-2">As a single person design team, I was responsible for user experience across the portfolio of products at Candis. Practically speaking, I conducted user research, produced design concepts and prototypes, documented epics and user stories, and contributed UI enhancements to the React codebase.</p>
-        <p>I also led the initiative to scale design to meet the needs of a growing engineering team through the development of a design system that served as the style guide and component library for current and future Candis products.</p>
+        <p>As the sole designer on a team of 10 engineers, I established the UI guidelines that defined Smartbooks, the flagship bookkeeping product, and built the design system that scaled across their financial Workflows product.</p>
       </WindowContent>
     </Window>
   );

--- a/src/components/windows/ExperienceWindow.tsx
+++ b/src/components/windows/ExperienceWindow.tsx
@@ -49,22 +49,22 @@ function ExperienceWindow({
         <ul>
           <li className="flex flex-col @3xl:flex-row @3xl:items-center @3xl:gap-4 pb-1">
             <span className="flex-none font-serif @3xl:font-sans text-lg @3xl:text-base"><button onClick={onShowMcKinsey} className="text-muted-foreground font-bold hover:bg-muted">McKinsey & Company</button></span>
-            <span className="flex-grow">Leading design across digital transformation initiatives.</span>
+            <span className="flex-grow">Leading McKinsey&apos;s in-house product design capability and the systems consultants rely on daily.</span>
             <span className="flex-none order-first @3xl:order-last @3xl:text-right text-sm @3xl:text-base text-muted-foreground">2021–Present</span>
           </li>
           <li className="flex flex-col @3xl:flex-row @3xl:items-center @3xl:gap-4 border-t py-1">
             <span className="flex-none font-serif @3xl:font-sans text-lg @3xl:text-base"><button onClick={onShowUP42} className="text-muted-foreground font-bold hover:bg-muted">UP42</button></span>
-            <span className="flex-grow">Established design practice and launched several keystone projects.</span>
+            <span className="flex-grow">Founding design leader who built UP42&apos;s design function from the ground up.</span>
             <span className="flex-none order-first @3xl:order-last @3xl:text-right text-sm @3xl:text-base text-muted-foreground">2019–2021</span>
           </li>
           <li className="flex flex-col @3xl:flex-row @3xl:items-center @3xl:gap-4 border-t py-1">
             <span className="flex-none font-serif @3xl:font-sans text-lg @3xl:text-base"><button onClick={onShowCandis} className="text-muted-foreground font-bold hover:bg-muted">Candis</button></span>
-            <span className="grow">Design team of one, hands-on from research to frontend.</span>
+            <span className="grow">Design team of one, hands-on from research through frontend delivery.</span>
             <span className="flex-none order-first @3xl:order-last @3xl:text-right text-sm @3xl:text-base text-muted-foreground">2017–2019</span>
           </li>
           <li className="flex flex-col @3xl:flex-row @3xl:items-center @3xl:gap-4 border-t pt-1">
             <span className="flex-none font-serif @3xl:font-sans text-lg @3xl:text-base"><button onClick={onShowUrbanSportsClub} className="text-muted-foreground font-bold hover:bg-muted">Urban Sports Club</button></span>
-            <span className="grow">Laid the technical and product foundations for European expansion.</span>
+            <span className="grow">Laid the technical and product foundations for Urban Sports Club&apos;s expansion across Europe.</span>
             <span className="flex-none order-first @3xl:order-last @3xl:text-right text-sm @3xl:text-base text-muted-foreground">2015</span>
           </li>
         </ul>

--- a/src/components/windows/McKinseyWindow.tsx
+++ b/src/components/windows/McKinseyWindow.tsx
@@ -15,10 +15,10 @@ export default function McKinseyWindow({ onClose, windowRef }: McKinseyWindowPro
       <WindowTitle>McKinsey & Company</WindowTitle>
       <WindowContent>
         <p className="text-sm text-muted-foreground">2021–Present</p>
-        <p className="font-serif text-xl mb-4">I&apos;m currently leading design across digital transformation initiatives at <a href="https://www.mckinsey.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "mckinsey_and_company_site", url: "https://www.mckinsey.com/" })}>McKinsey & Company</a>.</p>
-        <p className="mb-4">Leading a design team building Visual Graphics & Media services that serve tens of thousands of management consultants worldwide.</p>
-        <p className="mb-4">My work focuses on untangling complex, fragmented service experiences and creating systems that help balance limited resources with growing demand. I take projects from user research and opportunity mapping through high-fidelity prototypes to implementation.</p>
-        <p>I combine strategic thinking with hands-on execution, mentoring designers while collaborating closely with engineering, product, and operations teams.</p>
+        <p className="font-serif text-xl mb-4">I&apos;m currently leading <a href="https://www.mckinsey.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "mckinsey_and_company_site", url: "https://www.mckinsey.com/" })}>McKinsey & Company&apos;s</a> in-house product design capability, building the systems tens of thousands of consultants rely on daily.</p>
+        <p className="mb-4">Leading a design team of four within Visual Graphics & Media, McKinsey&apos;s in-house visual design capability serving tens of thousands of consultants globally. The work centres on untangling complex, fragmented service experiences and building systems that balance limited resources with growing demand, from research through to implementation.</p>
+        <p className="mb-4">I hire and mentor the team while staying close enough to the work to still be in the details &mdash; including designing and running Vibes to Pull Requests, a two-day technical literacy workshop now in its second cohort, taking 29 designers and researchers from zero to their first merged pull request in a live codebase.</p>
+        <p>I designed a Skills Map and Levelling Framework, a growth model that helps designers and their managers navigate progression across analytical, technical, and interpersonal dimensions.</p>
       </WindowContent>
     </Window>
   );

--- a/src/components/windows/UP42Window.tsx
+++ b/src/components/windows/UP42Window.tsx
@@ -30,10 +30,8 @@ function UP42Window({
       <WindowTitle>UP42</WindowTitle>
       <WindowContent>
         <p className="text-sm text-muted-foreground">2019–2021</p>
-        <p className="font-serif text-xl mb-4">I established design practice and launched several keystone projects at <a href="https://www.up42.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "up42_site", url: "https://www.up42.com/" })}>UP42</a>.</p>
-        <p className="mb-4">As the first design hire within the Airbus Defence and Space subsidiary, I established design practice within the organisation.</p>
-        <p className="mb-4">I was responsible for establishing a culture of continuous research through a combination of quantitative (SQL, BigQuery, etc.) and qualitative (user interviews, usability testing, etc.) techniques to ensure decisions were made with the best data and insights at hand.</p>
-        <p className="mb-4">I also worked closely with the frontend team to establish the foundations of our design system, through the design and implementation of token and component libraries.</p>
+        <p className="font-serif text-xl mb-4">I was the founding design leader at <a href="https://www.up42.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "up42_site", url: "https://www.up42.com/" })}>UP42</a>, building the design function from the ground up at an Airbus-incubated geospatial startup.</p>
+        <p className="mb-4">As the founding design leader at this Airbus-incubated geospatial startup, I built the design function from zero: hiring and leading the team to deliver product vision, research, and go-to-market across a platform and marketplace for geospatial data workflows and a developer API.</p>
         <button onClick={onShowDocumentationHub} className="text-xs/4 text-muted-foreground font-bold hover:bg-muted p-2 w-28 inline-flex flex-col items-center">
           <FileText strokeWidth={0.8} className="size-12"/>
           <span>documentation-hub-case-study.html</span>

--- a/src/components/windows/UrbanSportsClubWindow.tsx
+++ b/src/components/windows/UrbanSportsClubWindow.tsx
@@ -15,9 +15,9 @@ export default function UrbanSportsClubWindow({ onClose, windowRef }: UrbanSport
       <WindowTitle>Urban Sports Club</WindowTitle>
       <WindowContent>
         <p className="text-sm text-muted-foreground">2015</p>
-        <p className="font-serif text-xl mb-2">I helped lay the technical and product foundations for European expansion at <a href="https://urbansportsclub.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "urban_sports_club_site", url: "https://urbansportsclub.com/" })}>Urban Sports Club</a>.</p>
-        <p className="mb-2">I played a key technical leadership and product design role, responsible for the digital transformation of key technical infrastructure and the venue check-in experience. My achievements were instrumental to the ambitious expansion of the flat-rate sports membership from Berlin into over 88 cities and 8,000 sporting venues.</p>
-        <p>My key achievement was leading the delivery team, where I designed the REST API specification and mobile app experiences. Within three months, we replaced the existing manual membership card and log sheet processes with an API and mobile apps enabling members to check-in with their iOS and Android devices.</p>
+        <p className="font-serif text-xl mb-2">I laid the technical and product foundations for <a href="https://urbansportsclub.com/" target="_blank" rel="noopener noreferrer" className="text-muted-foreground font-bold bg-secondary hover:bg-accent" onClick={() => track("link_open", { id: "urban_sports_club_site", url: "https://urbansportsclub.com/" })}>Urban Sports Club&apos;s</a> expansion across Europe.</p>
+        <p className="mb-2">Led the digitisation of venue check-in from a manual card-and-log system to a full mobile product, designing the iOS and Android apps and the API interface powering both, while managing a team of three developers.</p>
+        <p>Shipped in three months, supporting expansion from Berlin to 88 cities and 8,000 venues.</p>
       </WindowContent>
     </Window>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update role headings and body copy for McKinsey, UP42, Candis, and Urban Sports Club in the Experience detail windows.
- Refresh Experience list-view blurbs so the overview reflects the same updated positioning and language.

## Testing
- `npm run lint`
- `npm run build`
- Manual UI verification across direct routes:
  - `/experience/mckinsey-and-company`
  - `/experience/up42`
  - `/experience/candis`
  - `/experience/urban-sports-club`

## Walkthrough artifacts
[experience-copy-clean-walkthrough.mp4](https://cursor.com/agents/bc-5354378a-11a7-4101-a313-ef62a2974a46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperience-copy-clean-walkthrough.mp4)
[Experience final state Urban Sports Club](https://cursor.com/agents/bc-5354378a-11a7-4101-a313-ef62a2974a46/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperience-copy-final-state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5354378a-11a7-4101-a313-ef62a2974a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5354378a-11a7-4101-a313-ef62a2974a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

