### PR TITLE
theme: adapt UI tokens to Omarchy Retro 82 palette

### DIFF
--- a/THEME_NOTES.md
+++ b/THEME_NOTES.md
@@ -1,0 +1,32 @@
+# Omarchy Retro 82 Theme Notes
+
+## Source
+- Theme repository: https://github.com/OldJobobo/omarchy-retro-82-theme
+- Primary palette source: `colors.toml` (plus tonal hints in `retro80.yaml` and UI intent in `gtk.css`).
+
+## Core palette extracted
+- Background: `#00172e`
+- Foreground: `#f6dcac`
+- Primary highlight (amber): `#faa968`
+- Teal/cyan support: `#028391`, `#3f8f8a`, `#8cbfb8`
+- Error/destructive: `#f85525`
+- Elevated dark surfaces: derived from the same navy/teal tonal ramp (`#01204e`, `#134e5a`)
+
+## shadcn token mapping decisions
+- Dark mode is the faithful mapping and uses the navy + cream + amber + teal balance as the base identity.
+- Light mode is conservatively derived (cream background + navy foreground + same accent family) because Omarchy Retro 82 is effectively dark-first.
+- Updated global tokens in `src/app/globals.css` for:
+  - `--background`, `--foreground`
+  - `--card`, `--popover`
+  - `--primary`, `--secondary`, `--muted`, `--accent`
+  - `--destructive`
+  - `--border`, `--input`, `--ring`
+  - `--chart-*`
+  - `--sidebar-*`
+
+## Manual component touches
+- Replaced hard-coded destructive foreground `text-white` with `text-destructive-foreground` in:
+  - `src/components/ui/button.tsx`
+  - `src/components/ui/badge.tsx`
+
+No layout or structure changes were made; styling remains token-driven.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  
+
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);
   --shadow-sm: var(--shadow-sm);
@@ -59,39 +59,40 @@
   --font-mono: 'inconsolata', monospace;
   --tracking-normal: 0em;
 
-  --background: oklch(0.9798 0.0045 78.2983);
-  --foreground: oklch(0.1504 0.0095 86.0541);
-  --card: oklch(0.9910 0.0041 91.4454);
-  --card-foreground: oklch(0.1504 0.0095 86.0541);
-  --popover: oklch(0.9910 0.0041 91.4454);
-  --popover-foreground: oklch(0.1504 0.0095 86.0541);
-  --primary: oklch(0.3798 0.0595 120.2827);
-  --primary-foreground: oklch(0.9798 0.0045 78.2983);
-  --secondary: oklch(0.9407 0.0086 84.5734);
-  --secondary-foreground: oklch(0.2495 0.0157 84.5097);
-  --muted: oklch(0.9407 0.0086 84.5734);
-  --muted-foreground: oklch(0.4501 0.0118 87.5327);
-  --accent: oklch(0.9101 0.0100 87.4746);
-  --accent-foreground: oklch(0.1801 0.0150 81.3705);
-  --destructive: oklch(0.5505 0.1800 25.0223);
-  --destructive-foreground: oklch(0.9798 0.0045 78.2983);
-  --border: oklch(0.8796 0.0101 87.4768);
-  --input: oklch(0.8796 0.0101 87.4768);
-  --ring: oklch(0.3500 0.0196 86.4530);
-  --chart-1: oklch(0.4499 0.0798 84.1579);
-  --chart-2: oklch(0.3798 0.0595 120.2827);
-  --chart-3: oklch(0.4206 0.0704 44.3694);
-  --chart-4: oklch(0.3493 0.0498 201.1523);
-  --chart-5: oklch(0.4804 0.0897 65.1386);
-  --sidebar: oklch(0.9706 0.0057 84.5662);
-  --sidebar-foreground: oklch(0.1504 0.0095 86.0541);
-  --sidebar-primary: oklch(0.1801 0.0150 81.3705);
-  --sidebar-primary-foreground: oklch(0.9798 0.0045 78.2983);
-  --sidebar-accent: oklch(0.9407 0.0086 84.5734);
-  --sidebar-accent-foreground: oklch(0.2495 0.0157 84.5097);
-  --sidebar-border: oklch(0.8796 0.0101 87.4768);
-  --sidebar-ring: oklch(0.3500 0.0196 86.4530);
-  
+  /* Conservative light-mode companion derived from Omarchy Retro 82 dark palette */
+  --background: oklch(0.97 0.017 89);
+  --foreground: oklch(0.23 0.055 252);
+  --card: oklch(0.99 0.01 89);
+  --card-foreground: oklch(0.23 0.055 252);
+  --popover: oklch(0.99 0.01 89);
+  --popover-foreground: oklch(0.23 0.055 252);
+  --primary: oklch(0.77 0.14 56);
+  --primary-foreground: oklch(0.2 0.045 252);
+  --secondary: oklch(0.94 0.018 208);
+  --secondary-foreground: oklch(0.3 0.038 231);
+  --muted: oklch(0.95 0.014 208);
+  --muted-foreground: oklch(0.47 0.04 227);
+  --accent: oklch(0.9 0.05 207);
+  --accent-foreground: oklch(0.28 0.04 231);
+  --destructive: oklch(0.64 0.2 40);
+  --destructive-foreground: oklch(0.98 0.01 89);
+  --border: oklch(0.83 0.025 220);
+  --input: oklch(0.83 0.025 220);
+  --ring: oklch(0.77 0.14 56);
+  --chart-1: oklch(0.77 0.14 56);
+  --chart-2: oklch(0.56 0.09 201);
+  --chart-3: oklch(0.58 0.12 44);
+  --chart-4: oklch(0.49 0.12 200);
+  --chart-5: oklch(0.67 0.13 183);
+  --sidebar: oklch(0.95 0.014 208);
+  --sidebar-foreground: oklch(0.23 0.055 252);
+  --sidebar-primary: oklch(0.77 0.14 56);
+  --sidebar-primary-foreground: oklch(0.2 0.045 252);
+  --sidebar-accent: oklch(0.9 0.05 207);
+  --sidebar-accent-foreground: oklch(0.28 0.04 231);
+  --sidebar-border: oklch(0.83 0.025 220);
+  --sidebar-ring: oklch(0.77 0.14 56);
+
   --radius-xs: 0;
   --radius-sm: 0;
   --radius-md: 0;
@@ -101,60 +102,61 @@
   --radius-3xl: 0;
   --radius-4xl: 0;
 
-  --shadow-2xs: 2px 2px 0px 0px hsl(28 18% 25% / 0.09);
-  --shadow-xs: 2px 2px 0px 0px hsl(28 18% 25% / 0.09);
-  --shadow-sm: 2px 2px 0px 0px hsl(28 18% 25% / 0.18), 2px 1px 2px -1px hsl(28 18% 25% / 0.18);
-  --shadow: 2px 2px 0px 0px hsl(28 18% 25% / 0.18), 2px 1px 2px -1px hsl(28 18% 25% / 0.18);
-  --shadow-md: 2px 2px 0px 0px hsl(28 18% 25% / 0.18), 2px 2px 4px -1px hsl(28 18% 25% / 0.18);
-  --shadow-lg: 2px 2px 0px 0px hsl(28 18% 25% / 0.18), 2px 4px 6px -1px hsl(28 18% 25% / 0.18);
-  --shadow-xl: 2px 2px 0px 0px hsl(28 18% 25% / 0.18), 2px 8px 10px -1px hsl(28 18% 25% / 0.18);
-  --shadow-2xl: 2px 2px 0px 0px hsl(28 18% 25% / 0.45);
+  --shadow-2xs: 2px 2px 0px 0px hsl(221 62% 9% / 0.09);
+  --shadow-xs: 2px 2px 0px 0px hsl(221 62% 9% / 0.09);
+  --shadow-sm: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 1px 2px -1px hsl(221 62% 9% / 0.18);
+  --shadow: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 1px 2px -1px hsl(221 62% 9% / 0.18);
+  --shadow-md: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 2px 4px -1px hsl(221 62% 9% / 0.18);
+  --shadow-lg: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 4px 6px -1px hsl(221 62% 9% / 0.18);
+  --shadow-xl: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 8px 10px -1px hsl(221 62% 9% / 0.18);
+  --shadow-2xl: 2px 2px 0px 0px hsl(221 62% 9% / 0.45);
 
   --spacing: 0.25rem;
 }
 
 .dark {
-  --background: oklch(0.1219 0.0106 95.0650);
-  --foreground: oklch(0.9498 0.0046 78.2977);
-  --card: oklch(0.1609 0.0115 80.9823);
-  --card-foreground: oklch(0.9498 0.0046 78.2977);
-  --popover: oklch(0.1801 0.0150 81.3705);
-  --popover-foreground: oklch(0.9498 0.0046 78.2977);
-  --primary: oklch(0.8801 0.0076 80.7197);
-  --primary-foreground: oklch(0.1504 0.0095 86.0541);
-  --secondary: oklch(0.2194 0.0177 86.7900);
-  --secondary-foreground: oklch(0.9193 0.0058 84.5672);
-  --muted: oklch(0.2194 0.0177 86.7900);
-  --muted-foreground: oklch(0.6502 0.0077 88.6692);
-  --accent: oklch(0.2790 0.0190 84.4799);
-  --accent-foreground: oklch(0.9498 0.0046 78.2977);
-  --destructive: oklch(0.6501 0.2008 24.9745);
-  --destructive-foreground: oklch(0.9498 0.0046 78.2977);
-  --border: oklch(0.5494 0.0099 84.5873);
-  --input: oklch(0.9498 0.0046 78.2977);
-  --ring: oklch(0.5494 0.0099 84.5873);
-  --chart-1: oklch(0.6495 0.1197 84.3080);
-  --chart-2: oklch(0.5805 0.1002 119.9073);
-  --chart-3: oklch(0.6191 0.1096 44.6789);
-  --chart-4: oklch(0.5497 0.0901 199.8126);
-  --chart-5: oklch(0.6814 0.1302 65.0777);
-  --sidebar: oklch(0.1609 0.0115 80.9823);
-  --sidebar-foreground: oklch(0.9498 0.0046 78.2977);
-  --sidebar-primary: oklch(0.6495 0.1197 84.3080);
-  --sidebar-primary-foreground: oklch(0.1219 0.0106 95.0650);
-  --sidebar-accent: oklch(0.2194 0.0177 86.7900);
-  --sidebar-accent-foreground: oklch(0.9193 0.0058 84.5672);
-  --sidebar-border: oklch(0.9498 0.0046 78.2977);
-  --sidebar-ring: oklch(0.4505 0.0152 86.8842);
+  /* Faithful Omarchy Retro 82 dark-mode mapping */
+  --background: oklch(0.2 0.045 252);
+  --foreground: oklch(0.92 0.05 79);
+  --card: oklch(0.24 0.05 246);
+  --card-foreground: oklch(0.92 0.05 79);
+  --popover: oklch(0.24 0.05 246);
+  --popover-foreground: oklch(0.92 0.05 79);
+  --primary: oklch(0.77 0.14 56);
+  --primary-foreground: oklch(0.2 0.045 252);
+  --secondary: oklch(0.31 0.06 220);
+  --secondary-foreground: oklch(0.9 0.035 193);
+  --muted: oklch(0.29 0.05 230);
+  --muted-foreground: oklch(0.72 0.04 203);
+  --accent: oklch(0.64 0.11 181);
+  --accent-foreground: oklch(0.2 0.045 252);
+  --destructive: oklch(0.64 0.2 40);
+  --destructive-foreground: oklch(0.2 0.045 252);
+  --border: oklch(0.45 0.06 214);
+  --input: oklch(0.45 0.06 214);
+  --ring: oklch(0.77 0.14 56);
+  --chart-1: oklch(0.77 0.14 56);
+  --chart-2: oklch(0.57 0.12 194);
+  --chart-3: oklch(0.58 0.12 44);
+  --chart-4: oklch(0.49 0.12 200);
+  --chart-5: oklch(0.67 0.13 183);
+  --sidebar: oklch(0.24 0.05 246);
+  --sidebar-foreground: oklch(0.92 0.05 79);
+  --sidebar-primary: oklch(0.77 0.14 56);
+  --sidebar-primary-foreground: oklch(0.2 0.045 252);
+  --sidebar-accent: oklch(0.31 0.06 220);
+  --sidebar-accent-foreground: oklch(0.9 0.035 193);
+  --sidebar-border: oklch(0.45 0.06 214);
+  --sidebar-ring: oklch(0.77 0.14 56);
 
-  --shadow-2xs: 2px 2px 0px 0px hsl(0 0% 5% / 0.09);
-  --shadow-xs: 2px 2px 0px 0px hsl(0 0% 5% / 0.09);
-  --shadow-sm: 2px 2px 0px 0px hsl(0 0% 5% / 0.18), 2px 1px 2px -1px hsl(0 0% 5% / 0.18);
-  --shadow: 2px 2px 0px 0px hsl(0 0% 5% / 0.18), 2px 1px 2px -1px hsl(0 0% 5% / 0.18);
-  --shadow-md: 2px 2px 0px 0px hsl(0 0% 5% / 0.18), 2px 2px 4px -1px hsl(0 0% 5% / 0.18);
-  --shadow-lg: 2px 2px 0px 0px hsl(0 0% 5% / 0.18), 2px 4px 6px -1px hsl(0 0% 5% / 0.18);
-  --shadow-xl: 2px 2px 0px 0px hsl(0 0% 5% / 0.18), 2px 8px 10px -1px hsl(0 0% 5% / 0.18);
-  --shadow-2xl: 2px 2px 0px 0px hsl(0 0% 5% / 0.45);
+  --shadow-2xs: 2px 2px 0px 0px hsl(221 62% 9% / 0.09);
+  --shadow-xs: 2px 2px 0px 0px hsl(221 62% 9% / 0.09);
+  --shadow-sm: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 1px 2px -1px hsl(221 62% 9% / 0.18);
+  --shadow: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 1px 2px -1px hsl(221 62% 9% / 0.18);
+  --shadow-md: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 2px 4px -1px hsl(221 62% 9% / 0.18);
+  --shadow-lg: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 4px 6px -1px hsl(221 62% 9% / 0.18);
+  --shadow-xl: 2px 2px 0px 0px hsl(221 62% 9% / 0.18), 2px 8px 10px -1px hsl(221 62% 9% / 0.18);
+  --shadow-2xl: 2px 2px 0px 0px hsl(221 62% 9% / 0.45);
 }
 
 @layer base {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-transparent bg-destructive text-destructive-foreground [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
### Motivation
- Bring the Omarchy Retro 82 visual identity into the app by mapping its palette into the existing shadcn/Tailwind design-token system rather than sprinkling raw colors across components. 
- Preserve shadcn semantics (`bg-background`, `text-foreground`, `bg-primary`, etc.) and keep changes minimal and reversible by preferring global token edits over component-level restyling. 
- Support both light and dark modes by providing a faithful dark mapping (Omarchy is dark-first) and a conservative derived light companion to keep accessibility and contrast.

### Description
- Mapped Omarchy Retro 82 core palette into the app-wide CSS variables in `src/app/globals.css`, updating semantic tokens including `--background`, `--foreground`, `--card`, `--popover`, `--primary`, `--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--input`, `--ring`, `--chart-*`, and `--sidebar-*` for both `.dark` and `:root` modes. 
- Implemented a faithful dark-mode mapping based on Omarchy navy/cream/amber/teal, and a conservative derived light-mode companion to preserve dual-mode support and accessibility. 
- Made two minimal component fixes to use semantic destructive foregrounds instead of hard-coded white by replacing `text-white` with `text-destructive-foreground` in `src/components/ui/button.tsx` and `src/components/ui/badge.tsx`. 
- Added `THEME_NOTES.md` documenting the source theme, extracted palette, token mapping rationale, derived colors, and the small manual component touches; no layout or structural changes were made.

### Testing
- Ran lint with `npm run lint` which completed with no ESLint warnings or errors. 
- Built the project with `npm run build` which compiled and generated the production build successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edf7071980832aab90f2233ddf4743)